### PR TITLE
Ensure UI alias takes precedence over plugin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
 # signalk-autopilot-simrad
-a signalk plugin for control of SIMRAD autopilot
+
+A Signal K server plugin for controlling **Simrad SimNet/NMEA 2000 tillerpilots** (TP22/TP32 and compatible pilots) by transmitting **PGN 127237 – Heading/Track Control**. The plugin targets gateways that accept raw NMEA 2000 frames over UDP using the Yacht Devices `YDRAW` format and exposes both REST and Signal K `PUT` interfaces for steering commands.
+
+Once enabled, Signal K registers the plugin under the slug `signalk-autopilot-simrad`, which means the REST API is available at `/plugins/signalk-autopilot-simrad/*` and the optional UI is hosted at `/signalk-autopilot-simrad/`.
+
+## Features
+
+- Standby / Auto / Wind / Track mode control via PGN 127237
+- Heading nudges (+/-1°, +/-10°) plus tack and gybe helpers
+- Set commanded heading explicitly from REST, WebSocket PUTs, or the optional UI
+- UDP writer for Yacht Devices YDWG gateways (customisable host/port/source/destination)
+- Uses live heading data from Signal K (magnetic or true) for safe heading capture
+- Optional passive subscriptions to navigation and wind data so Track/Wind modes have the information they need on the NMEA 2000 bus
+
+## Requirements
+
+- Signal K Server v2 or later with Node.js 18+
+- A write-capable NMEA 2000/SimNet gateway (tested format: Yacht Devices YDWG-02/03 using raw frame output)
+- Simrad tillerpilot connected to the same NMEA 2000 network
+
+## Installation
+
+1. Install the plugin into your Signal K server (for example on a Raspberry Pi running `@signalk/server`):
+
+   ```sh
+   cd ~/.signalk/node_modules
+   git clone https://github.com/shlandrews/signalk-autopilot-simrad.git
+   ```
+
+2. Restart the Signal K server.
+3. In the Signal K admin UI open **Server → Appstore → Installed**, locate **Simrad Autopilot (TP22/TP32) – NMEA 2000**, and enable it.
+4. Configure the plugin (see options below) and save.
+
+## Configuration options
+
+| Option | Description |
+| --- | --- |
+| **Gateway host/IP** | IP address or hostname of the UDP gateway (default `192.168.4.1`). |
+| **Gateway UDP port** | UDP port where the gateway accepts raw frames (default `1456`). |
+| **NMEA 2000 source address** | Source address used for outgoing PGNs (0–252, default `25`). |
+| **Destination address** | Destination address for frames (`255` for broadcast works on Simrad networks). |
+| **Heading reference** | `magnetic` or `true`. Determines which heading Signal K data the plugin favours when capturing a reference for auto mode. |
+
+The plugin listens to `navigation.headingMagnetic` and `navigation.headingTrue` from the Signal K data model to keep track of the vessel heading. If no live heading data is available, auto-engage and nudge commands will return an error rather than guessing.
+
+## REST API
+
+Routes are available under `/plugins/signalk-autopilot-simrad/*`:
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /standby` | Put the pilot into standby. |
+| `POST /auto` | Engage auto mode using the last commanded heading (or the current vessel heading if none has been set). |
+| `POST /wind` | Engage wind mode (requires true/apparent wind data on the network). |
+| `POST /track` | Engage track mode (requires XTE/Bearing/Waypoint PGNs on the network). |
+| `POST /plus1`, `/minus1` | Adjust heading by ±1°. |
+| `POST /plus10`, `/minus10` | Adjust heading by ±10°. |
+| `POST /tack`, `/gybe` | Large adjustments for tack (+100°) or gybe (-100°). |
+| `POST /setHeading` | Set a specific commanded heading. Supply JSON `{"heading": 42}` or query `?heading=42`. |
+
+Example commands:
+
+```sh
+curl -X POST http://signalk.local:3000/plugins/signalk-autopilot-simrad/auto
+curl -X POST http://signalk.local:3000/plugins/signalk-autopilot-simrad/setHeading \
+  -H 'Content-Type: application/json' \
+  -d '{"heading": 215}'
+```
+
+## WebSocket / PUT support
+
+Signal K clients can issue PUT requests to `steering.autopilot.command` on `vessels.self`. Accepted payloads include:
+
+- String commands: `"standby"`, `"auto"`, `"wind"`, `"track"`, `"plus1"`, `"minus10"`, `"tack"`, `"gybe"`.
+- Numeric heading (degrees): `215` engages auto and sets heading to 215°.
+- Object payloads:
+  - `{ "mode": "auto" }`
+  - `{ "heading": 048 }`
+  - `{ "heading": 048, "mode": "wind" }`
+  - `{ "delta": 10 }` (equivalent to +10° nudge)
+  - `{ "action": "plus1" }`
+
+The handler returns `state: "SUCCESS"` on completion or provides an error message if the command cannot be fulfilled (for example when no heading data is available).
+
+## Optional UI stub
+
+A minimal web UI lives in [`public/`](public/) for experimentation or further development. When the plugin is enabled, Signal K serves it automatically at:
+
+```
+http://<your-server>:3000/signalk-autopilot-simrad/
+```
+
+The UI calls the REST endpoints above from the browser so you can drive the pilot directly. It is designed as a starting point—feel free to customise the layout or embed it into your own dashboards.
+
+![Simrad autopilot UI preview showing four primary buttons](public/ui-preview.svg)
+
+## Development
+
+- The plugin sends raw `YDRAW` UDP lines; if you use a different bridge (e.g., Actisense NGT-1 with `signalk-to-nmea2000`), replace the `send127237` implementation with your preferred writer.
+- `index.js` is intentionally dependency-free and targets Node.js 18+ as required by modern Signal K servers.
+- Contributions and field reports welcome! Please open an issue or pull request.
+
+## License
+
+This project is released under the [MIT License](LICENSE).

--- a/index.js
+++ b/index.js
@@ -1,0 +1,657 @@
+const dgram = require('dgram');
+const fs = require('fs');
+const path = require('path');
+
+const PLUGIN_ID = 'signalk-autopilot-simrad';
+const UI_ROUTE = `/${PLUGIN_ID}`;
+const REST_BASE_PATH = `/plugins/${PLUGIN_ID}`;
+
+const MODE_MAP = {
+  standby: 0,
+  auto: 1,
+  wind: 2,
+  track: 3
+};
+
+function normalizeDegrees(deg) {
+  if (!Number.isFinite(deg)) {
+    return null;
+  }
+  let value = deg % 360;
+  if (value < 0) {
+    value += 360;
+  }
+  return value;
+}
+
+function radiansToDegrees(rad) {
+  return (rad * 180) / Math.PI;
+}
+
+function pack127237({ sid, headingRefMag, mode, commandedHeadingDeg }) {
+  const payload = Buffer.alloc(16, 0xff);
+
+  payload.writeUInt8(sid & 0xff, 0);
+
+  const headingReferenceBits = headingRefMag ? 1 : 0;
+  const modeBits = MODE_MAP[mode] ?? MODE_MAP.standby;
+  payload.writeUInt8((headingReferenceBits & 0x03) | ((modeBits & 0x07) << 2), 1);
+
+  payload.writeInt16LE(0, 2);
+
+  let headingToSteer = 0xffff;
+  if (typeof commandedHeadingDeg === 'number') {
+    const radians = (commandedHeadingDeg * Math.PI) / 180;
+    headingToSteer = Math.round(radians * 10000) & 0xffff;
+  }
+  payload.writeUInt16LE(headingToSteer, 4);
+
+  return payload;
+}
+
+function payloadToHexString(payload) {
+  return Array.from(payload)
+    .map((byte) => byte.toString(16).padStart(2, '0').toUpperCase())
+    .join(',');
+}
+
+module.exports = function simradAutopilotPlugin(app) {
+  const plugin = {};
+
+  let udpSocket;
+  let config = {
+    enabled: true,
+    ydwgHost: '192.168.4.1',
+    ydwgPort: 1456,
+    src: 25,
+    dst: 255,
+    headingReference: 'magnetic'
+  };
+
+  let headingMagDeg = null;
+  let headingTrueDeg = null;
+  let currentHeadingDeg = null;
+  let commandedHeadingDeg = null;
+  let sid = 0;
+  let subscriptions = [];
+  let routesRegistered = false;
+  let putHandlersRegistered = false;
+  let webAppRegistered = false;
+  let uiAliasLayer = null;
+
+  function updateCurrentHeading() {
+    const preferTrue = config.headingReference === 'true';
+    const candidate = preferTrue
+      ? (headingTrueDeg ?? headingMagDeg)
+      : (headingMagDeg ?? headingTrueDeg);
+
+    if (typeof candidate === 'number') {
+      currentHeadingDeg = normalizeDegrees(candidate);
+    }
+  }
+
+  function openUdpSocket() {
+    closeUdpSocket();
+    udpSocket = dgram.createSocket('udp4');
+    udpSocket.on('error', (err) => {
+      app.error(`Simrad autopilot UDP error: ${err.message}`);
+      if (app.setPluginError) {
+        app.setPluginError(err.message);
+      }
+    });
+  }
+
+  function closeUdpSocket() {
+    if (udpSocket) {
+      try {
+        udpSocket.close();
+      } catch (err) {
+        app.error(`Failed to close UDP socket: ${err.message}`);
+      }
+    }
+    udpSocket = null;
+  }
+
+  function buildYdrawFrame(pgn, payload) {
+    const priority = 3;
+    const length = payload.length;
+    const src = config.src & 0xff;
+    const dst = config.dst & 0xff;
+    const hex = payloadToHexString(payload);
+    const line = `YDRAW,${priority},${pgn},${src},${dst},${length},${hex}\r\n`;
+    return Buffer.from(line, 'ascii');
+  }
+
+  function send127237({ mode, heading }) {
+    if (!udpSocket) {
+      app.error('Simrad autopilot UDP socket is not initialised');
+      return;
+    }
+    const normalisedHeading = typeof heading === 'number' ? normalizeDegrees(heading) : null;
+    const payload = pack127237({
+      sid: (sid = (sid + 1) & 0xff),
+      headingRefMag: config.headingReference !== 'true',
+      mode,
+      commandedHeadingDeg: normalisedHeading
+    });
+    const frame = buildYdrawFrame(127237, payload);
+    udpSocket.send(frame, config.ydwgPort, config.ydwgHost, (err) => {
+      if (err) {
+        app.error(`Failed to send PGN 127237: ${err.message}`);
+        if (app.setPluginError) {
+          app.setPluginError(err.message);
+        }
+      } else {
+        app.debug(
+          `Sent Simrad autopilot command mode=${mode} heading=${
+            normalisedHeading != null ? normalisedHeading.toFixed(1) : 'NA'
+          } to ${config.ydwgHost}:${config.ydwgPort}`
+        );
+        if (app.setPluginStatus) {
+          app.setPluginStatus(
+            `Sending PGN 127237 to ${config.ydwgHost}:${config.ydwgPort}`
+          );
+        }
+      }
+    });
+  }
+
+  function nudgeHeading(deltaDeg) {
+    const base =
+      typeof commandedHeadingDeg === 'number'
+        ? commandedHeadingDeg
+        : typeof currentHeadingDeg === 'number'
+        ? currentHeadingDeg
+        : null;
+    if (base == null) {
+      return null;
+    }
+    commandedHeadingDeg = normalizeDegrees(base + deltaDeg);
+    send127237({ mode: 'auto', heading: commandedHeadingDeg });
+    return commandedHeadingDeg;
+  }
+
+  function setHeadingDegrees(heading, mode = 'auto') {
+    if (!Number.isFinite(heading)) {
+      return { ok: false, statusCode: 400, message: 'Heading must be a finite number' };
+    }
+    commandedHeadingDeg = normalizeDegrees(heading);
+    send127237({ mode, heading: commandedHeadingDeg });
+    return { ok: true, heading: commandedHeadingDeg };
+  }
+
+  function applyMode(mode) {
+    if (!Object.prototype.hasOwnProperty.call(MODE_MAP, mode)) {
+      return { ok: false, statusCode: 400, message: `Unsupported mode "${mode}"` };
+    }
+    if (mode === 'auto' && typeof commandedHeadingDeg !== 'number') {
+      if (typeof currentHeadingDeg !== 'number') {
+        return { ok: false, statusCode: 409, message: 'No heading available to engage auto mode' };
+      }
+      commandedHeadingDeg = currentHeadingDeg;
+    }
+    if (mode === 'standby') {
+      commandedHeadingDeg = null;
+    }
+    send127237({ mode, heading: commandedHeadingDeg });
+    return { ok: true, heading: commandedHeadingDeg };
+  }
+
+  function applyCommand(command) {
+    if (typeof command === 'number') {
+      return setHeadingDegrees(command, 'auto');
+    }
+
+    if (typeof command === 'string') {
+      const lowered = command.toLowerCase();
+      if (lowered === 'plus1' || lowered === '+1') {
+        const heading = nudgeHeading(1);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for +1 command' };
+        }
+        return { ok: true, heading };
+      }
+      if (lowered === 'minus1' || lowered === '-1') {
+        const heading = nudgeHeading(-1);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for -1 command' };
+        }
+        return { ok: true, heading };
+      }
+      if (lowered === 'plus10' || lowered === '+10') {
+        const heading = nudgeHeading(10);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for +10 command' };
+        }
+        return { ok: true, heading };
+      }
+      if (lowered === 'minus10' || lowered === '-10') {
+        const heading = nudgeHeading(-10);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for -10 command' };
+        }
+        return { ok: true, heading };
+      }
+      if (lowered === 'tack') {
+        const heading = nudgeHeading(100);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for tack command' };
+        }
+        return { ok: true, heading };
+      }
+      if (lowered === 'gybe' || lowered === 'jibe') {
+        const heading = nudgeHeading(-100);
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available for gybe command' };
+        }
+        return { ok: true, heading };
+      }
+      return applyMode(lowered);
+    }
+
+    if (command && typeof command === 'object') {
+      if (Object.prototype.hasOwnProperty.call(command, 'heading')) {
+        return setHeadingDegrees(command.heading, command.mode ?? 'auto');
+      }
+      if (Object.prototype.hasOwnProperty.call(command, 'delta')) {
+        const heading = nudgeHeading(Number(command.delta));
+        if (heading == null) {
+          return { ok: false, statusCode: 409, message: 'No heading available to adjust' };
+        }
+        return { ok: true, heading };
+      }
+      if (Object.prototype.hasOwnProperty.call(command, 'action')) {
+        return applyCommand(command.action);
+      }
+      if (Object.prototype.hasOwnProperty.call(command, 'mode')) {
+        return applyMode(command.mode);
+      }
+    }
+
+    return { ok: false, statusCode: 400, message: 'Unsupported command payload' };
+  }
+
+  function respond(res, result) {
+    if (result.ok) {
+      res.json({ ok: true, heading: result.heading ?? null });
+    } else {
+      res.status(result.statusCode ?? 400).json({ ok: false, error: result.message });
+    }
+  }
+
+  function startSubscriptions() {
+    stopSubscriptions();
+
+    if (!app.streambundle || typeof app.streambundle.getSelfStream !== 'function') {
+      app.error('Signal K streambundle is not available; heading tracking disabled');
+      return;
+    }
+
+    const subscribe = (path, handler) => {
+      try {
+        const stream = app.streambundle.getSelfStream(path);
+        if (stream && typeof stream.onValue === 'function') {
+          const unsubscribe = stream.onValue(handler);
+          if (typeof unsubscribe === 'function') {
+            subscriptions.push(unsubscribe);
+          }
+        }
+      } catch (err) {
+        app.error(`Failed to subscribe to ${path}: ${err.message}`);
+      }
+    };
+
+    subscribe('navigation.headingMagnetic', (value) => {
+      if (typeof value === 'number') {
+        headingMagDeg = normalizeDegrees(radiansToDegrees(value));
+        updateCurrentHeading();
+      }
+    });
+
+    subscribe('navigation.headingTrue', (value) => {
+      if (typeof value === 'number') {
+        headingTrueDeg = normalizeDegrees(radiansToDegrees(value));
+        updateCurrentHeading();
+      }
+    });
+
+    const passivePaths = [
+      'navigation.courseRhumbline.crossTrackError',
+      'navigation.courseRhumbline.bearingToDestination',
+      'navigation.courseRhumbline.nextPoint.distance',
+      'environment.wind.angleApparent',
+      'environment.wind.angleTrueWater'
+    ];
+    passivePaths.forEach((path) => subscribe(path, () => {}));
+  }
+
+  function stopSubscriptions() {
+    subscriptions.forEach((unsubscribe) => {
+      try {
+        if (typeof unsubscribe === 'function') {
+          unsubscribe();
+        }
+      } catch (err) {
+        app.error(`Failed to unsubscribe: ${err.message}`);
+      }
+    });
+    subscriptions = [];
+    headingMagDeg = null;
+    headingTrueDeg = null;
+    currentHeadingDeg = null;
+  }
+
+  function registerPutHandlers() {
+    if (!app.registerPutHandler || putHandlersRegistered) {
+      return;
+    }
+
+    app.registerPutHandler('vessels.self', 'steering.autopilot.command', (_context, _path, value, callback) => {
+      const result = applyCommand(value);
+      if (result.ok) {
+        callback({ state: 'SUCCESS', statusCode: 200 });
+      } else {
+        callback({
+          state: 'FAILURE',
+          statusCode: result.statusCode ?? 400,
+          message: result.message
+        });
+      }
+    });
+
+    putHandlersRegistered = true;
+  }
+
+  function unregisterPutHandlers() {
+    if (!putHandlersRegistered || !app.unregisterPutHandler) {
+      putHandlersRegistered = false;
+      return;
+    }
+
+    app.unregisterPutHandler('vessels.self', 'steering.autopilot.command');
+    putHandlersRegistered = false;
+  }
+
+  function addRoutes(router) {
+    if (routesRegistered) {
+      return;
+    }
+
+    router.post('/standby', (_req, res) => {
+      respond(res, applyMode('standby'));
+    });
+
+    router.post('/auto', (_req, res) => {
+      respond(res, applyMode('auto'));
+    });
+
+    router.post('/wind', (_req, res) => {
+      respond(res, applyMode('wind'));
+    });
+
+    router.post('/track', (_req, res) => {
+      respond(res, applyMode('track'));
+    });
+
+    router.post('/plus1', (_req, res) => {
+      const heading = nudgeHeading(1);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available to adjust' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/minus1', (_req, res) => {
+      const heading = nudgeHeading(-1);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available to adjust' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/plus10', (_req, res) => {
+      const heading = nudgeHeading(10);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available to adjust' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/minus10', (_req, res) => {
+      const heading = nudgeHeading(-10);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available to adjust' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/tack', (_req, res) => {
+      const heading = nudgeHeading(100);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available for tack' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/gybe', (_req, res) => {
+      const heading = nudgeHeading(-100);
+      if (heading == null) {
+        res.status(409).json({ ok: false, error: 'No heading available for gybe' });
+        return;
+      }
+      res.json({ ok: true, heading });
+    });
+
+    router.post('/setHeading', (req, res) => {
+      const fromBody = req.body && Number(req.body.heading);
+      const fromQuery = req.query && Number(req.query.heading);
+      const heading = Number.isFinite(fromBody) ? fromBody : fromQuery;
+      respond(res, setHeadingDegrees(heading, 'auto'));
+    });
+
+    routesRegistered = true;
+  }
+
+  function registerUiAlias() {
+    if (uiAliasLayer) {
+      return;
+    }
+
+    const expressApp =
+      (typeof app.getExpressApp === 'function' && app.getExpressApp()) ||
+      app.expressApp ||
+      (app.server && app.server.app) ||
+      null;
+
+    if (!expressApp || typeof expressApp.use !== 'function') {
+      app.debug(
+        `Express application not available; cannot mount UI alias at ${UI_ROUTE}`
+      );
+      return;
+    }
+
+    let express;
+    try {
+      express = require('express');
+    } catch (err) {
+      app.error(
+        `Express dependency not available; cannot expose UI alias at ${UI_ROUTE}: ${err.message}`
+      );
+      return;
+    }
+
+    const staticDir = path.join(__dirname, 'public');
+    const indexPath = path.join(staticDir, 'index.html');
+
+    const router = express.Router();
+    const serveIndex = (_req, res, next) => {
+      fs.access(indexPath, fs.constants.R_OK, (accessErr) => {
+        if (accessErr) {
+          next(accessErr);
+          return;
+        }
+        res.sendFile(indexPath, (sendErr) => {
+          if (sendErr) {
+            next(sendErr);
+          }
+        });
+      });
+    };
+    router.get('/', serveIndex);
+    router.head('/', serveIndex);
+    router.use('/', express.static(staticDir, { redirect: false }));
+
+    expressApp.use(UI_ROUTE, router);
+
+    if (expressApp._router && Array.isArray(expressApp._router.stack)) {
+      const stack = expressApp._router.stack;
+      const index = stack.findIndex((layer) => layer && layer.handle === router);
+      if (index > 0) {
+        const [layer] = stack.splice(index, 1);
+        stack.unshift(layer);
+        app.debug(
+          `Elevated Simrad autopilot UI alias to the front of the Express stack for ${UI_ROUTE}`
+        );
+      }
+    }
+
+    uiAliasLayer = { app: expressApp, router };
+    app.debug(`Mounted Simrad autopilot UI alias at ${UI_ROUTE}`);
+  }
+
+  function unregisterUiAlias() {
+    if (!uiAliasLayer) {
+      return;
+    }
+
+    const { app: expressApp, router } = uiAliasLayer;
+    if (expressApp && expressApp._router && Array.isArray(expressApp._router.stack)) {
+      expressApp._router.stack = expressApp._router.stack.filter(
+        (layer) => layer && layer.handle !== router
+      );
+    }
+
+    uiAliasLayer = null;
+  }
+
+  function registerWebApp() {
+    if (!webAppRegistered && typeof app.registerPluginWebapp === 'function') {
+      try {
+        app.registerPluginWebapp(
+          plugin.id,
+          plugin.name,
+          path.join(__dirname, 'public')
+        );
+        webAppRegistered = true;
+        app.debug(`Registered Simrad autopilot UI at /plugins/${PLUGIN_ID}`);
+      } catch (err) {
+        app.error(`Failed to register Simrad autopilot UI: ${err.message}`);
+      }
+    } else if (!webAppRegistered) {
+      app.debug(
+        'Signal K host does not support registerPluginWebapp; skipping admin UI registration.'
+      );
+    }
+
+    registerUiAlias();
+  }
+
+  function unregisterWebApp() {
+    if (webAppRegistered && typeof app.unregisterPluginWebapp === 'function') {
+      try {
+        app.unregisterPluginWebapp(plugin.id);
+      } catch (err) {
+        app.error(`Failed to unregister Simrad autopilot UI: ${err.message}`);
+      }
+    }
+
+    webAppRegistered = false;
+    unregisterUiAlias();
+  }
+
+  plugin.id = PLUGIN_ID;
+  plugin.name = 'Simrad Autopilot (TP22/TP32) – NMEA 2000';
+  plugin.description = 'Control Simrad tillerpilots via PGN 127237 sent as UDP YDRAW frames.';
+
+  plugin.schema = {
+    type: 'object',
+    properties: {
+      enabled: {
+        type: 'boolean',
+        title: 'Enabled',
+        default: config.enabled
+      },
+      ydwgHost: {
+        type: 'string',
+        title: 'Gateway host/IP',
+        default: config.ydwgHost
+      },
+      ydwgPort: {
+        type: 'number',
+        title: 'Gateway UDP port',
+        default: config.ydwgPort
+      },
+      src: {
+        type: 'number',
+        title: 'NMEA 2000 source address (0-252)',
+        default: config.src
+      },
+      dst: {
+        type: 'number',
+        title: 'Destination address (255 for broadcast)',
+        default: config.dst
+      },
+      headingReference: {
+        type: 'string',
+        title: 'Heading reference for commands',
+        enum: ['magnetic', 'true'],
+        default: config.headingReference
+      }
+    }
+  };
+
+  plugin.registerWithRouter = (router) => {
+    const wasRegistered = routesRegistered;
+    addRoutes(router);
+    if (!wasRegistered && routesRegistered) {
+      app.debug(`Simrad autopilot REST endpoints mounted at ${REST_BASE_PATH}/*`);
+    }
+  };
+
+  plugin.start = (options) => {
+    config = Object.assign({}, config, options || {});
+    commandedHeadingDeg = null;
+    openUdpSocket();
+    startSubscriptions();
+    registerPutHandlers();
+    registerWebApp();
+    updateCurrentHeading();
+    app.debug(
+      `Simrad autopilot plugin started; sending PGN 127237 to ${config.ydwgHost}:${config.ydwgPort}`
+    );
+    if (app.setPluginStatus) {
+      app.setPluginStatus(
+        `Ready to send PGN 127237 to ${config.ydwgHost}:${config.ydwgPort}`
+      );
+    }
+  };
+
+  plugin.stop = () => {
+    stopSubscriptions();
+    unregisterPutHandlers();
+    unregisterWebApp();
+    closeUdpSocket();
+    commandedHeadingDeg = null;
+    if (app.setPluginStatus) {
+      app.setPluginStatus('Simrad autopilot plugin stopped');
+    }
+    app.debug('Simrad autopilot plugin stopped');
+  };
+
+  return plugin;
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "signalk-autopilot-simrad",
+  "version": "0.1.0",
+  "description": "Signal K plugin for controlling Simrad SimNet/NMEA 2000 tillerpilots via PGN 127237.",
+  "keywords": [
+    "signalk-node-server-plugin",
+    "signalk-plugin",
+    "signalk-category-nmea-2000",
+    "signalk",
+    "simrad",
+    "autopilot",
+    "nmea2000",
+    "simnet",
+    "tillerpilot"
+  ],
+  "author": "Shlandrews",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shlandrews/signalk-autopilot-simrad.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shlandrews/signalk-autopilot-simrad/issues"
+  },
+  "homepage": "https://github.com/shlandrews/signalk-autopilot-simrad#readme",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,124 @@
+(() => {
+  const PLUGIN_ID = 'signalk-autopilot-simrad';
+  const BASE_PATH = `/plugins/${PLUGIN_ID}`;
+  const STORAGE_KEY = `${PLUGIN_ID}-base-url`;
+
+  const serverInput = document.getElementById('serverBase');
+  const statusEl = document.getElementById('status');
+  const headingForm = document.getElementById('headingForm');
+  const headingInput = document.getElementById('headingInput');
+  const buttons = document.querySelectorAll('button[data-endpoint]');
+
+  const defaultBase = window.location.origin || 'http://localhost:3000';
+
+  function readStoredBase() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  function writeStoredBase(value) {
+    try {
+      if (value) {
+        window.localStorage.setItem(STORAGE_KEY, value);
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (_err) {
+      // ignore storage errors (e.g., disabled cookies)
+    }
+  }
+
+  const storedBase = readStoredBase();
+  serverInput.value = storedBase || defaultBase;
+
+  function pluginBaseUrl() {
+    const base = (serverInput.value || defaultBase).trim();
+    if (!base) {
+      return `${defaultBase}${BASE_PATH}`;
+    }
+    return `${base.replace(/\/$/, '')}${BASE_PATH}`;
+  }
+
+  function setStatus(message, isError = false) {
+    if (typeof message === 'object') {
+      statusEl.textContent = JSON.stringify(message, null, 2);
+    } else {
+      statusEl.textContent = message;
+    }
+    statusEl.classList.toggle('error', Boolean(isError));
+  }
+
+  async function post(endpoint, body) {
+    const url = `${pluginBaseUrl()}${endpoint}`;
+    const options = {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json'
+      }
+    };
+    if (body !== undefined) {
+      options.headers['Content-Type'] = 'application/json';
+      options.body = JSON.stringify(body);
+    }
+
+    try {
+      const response = await fetch(url, options);
+      const text = await response.text();
+      let data;
+      try {
+        data = text ? JSON.parse(text) : null;
+      } catch (_err) {
+        data = text;
+      }
+
+      if (!response.ok || (data && typeof data === 'object' && data.ok === false)) {
+        const errorMessage =
+          (data && data.error) || response.statusText || 'Request failed';
+        throw new Error(errorMessage);
+      }
+
+      setStatus(data ?? { ok: true });
+      if (data && typeof data === 'object' && typeof data.heading === 'number') {
+        headingInput.value = Math.round(data.heading).toString().padStart(3, '0');
+      }
+    } catch (err) {
+      setStatus(`Error: ${err.message}`, true);
+    }
+  }
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const endpoint = button.dataset.endpoint;
+      if (!endpoint) {
+        return;
+      }
+      post(endpoint);
+    });
+  });
+
+  headingForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const raw = headingInput.value.trim();
+    if (!raw) {
+      setStatus('Please enter a heading between 0 and 359 degrees.', true);
+      return;
+    }
+    const heading = Number(raw);
+    if (!Number.isFinite(heading) || heading < 0 || heading >= 360) {
+      setStatus('Heading must be a number between 0 and 359.', true);
+      return;
+    }
+    post('/setHeading', { heading });
+  });
+
+  serverInput.addEventListener('change', () => {
+    const value = serverInput.value.trim();
+    writeStoredBase(value);
+  });
+
+  setStatus('Ready.');
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simrad Autopilot Control</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="panel">
+      <header>
+        <h1>Simrad Autopilot</h1>
+        <p class="subtitle">Send REST commands to the Signal K Simrad autopilot plugin.</p>
+      </header>
+
+      <section class="config">
+        <label for="serverBase">Signal K server base URL</label>
+        <input id="serverBase" type="text" placeholder="http://localhost:3000" />
+      </section>
+
+      <section class="group">
+        <h2>Modes</h2>
+        <div class="button-grid">
+          <button data-endpoint="/standby">Standby</button>
+          <button data-endpoint="/auto">Auto</button>
+          <button data-endpoint="/wind">Wind</button>
+          <button data-endpoint="/track">Track</button>
+        </div>
+      </section>
+
+      <section class="group">
+        <h2>Heading nudges</h2>
+        <div class="button-grid">
+          <button data-endpoint="/minus10">−10°</button>
+          <button data-endpoint="/minus1">−1°</button>
+          <button data-endpoint="/plus1">+1°</button>
+          <button data-endpoint="/plus10">+10°</button>
+          <button data-endpoint="/tack">Tack</button>
+          <button data-endpoint="/gybe">Gybe</button>
+        </div>
+      </section>
+
+      <section class="group">
+        <h2>Set heading</h2>
+        <form id="headingForm">
+          <label for="headingInput">Heading (degrees)</label>
+          <div class="heading-row">
+            <input id="headingInput" type="number" min="0" max="359" step="1" placeholder="0-359" />
+            <button type="submit">Set &amp; Engage Auto</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="group status" aria-live="polite">
+        <h2>Status</h2>
+        <pre id="status">Ready.</pre>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,152 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.4;
+}
+
+body {
+  margin: 0;
+  padding: 1.5rem;
+  background: #f4f6fb;
+  color: #1a1d23;
+}
+
+.panel {
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: 1.5rem;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 18, 34, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #10131a;
+    color: #f1f4ff;
+  }
+
+  .panel {
+    background: #1a1f2b;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  }
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: #52607a;
+  font-size: 0.95rem;
+}
+
+.config {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.config input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccd4e0;
+  font-size: 1rem;
+}
+
+.group {
+  margin-top: 1.5rem;
+}
+
+.group h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #2d3954;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.75rem 0.5rem;
+  border: none;
+  border-radius: 10px;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #007aff, #0056d6);
+  color: #ffffff;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover,
+button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 122, 255, 0.3);
+  outline: none;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.heading-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.heading-row input {
+  flex: 1;
+  padding: 0.7rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccd4e0;
+  font-size: 1rem;
+}
+
+.status pre {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: #f1f4ff;
+  border: 1px solid #d5dcf0;
+  min-height: 3.5rem;
+  overflow-x: auto;
+  font-family: 'Fira Code', 'Source Code Pro', Consolas, monospace;
+  font-size: 0.9rem;
+}
+
+.status pre.error {
+  color: #b3172f;
+}
+
+@media (prefers-color-scheme: dark) {
+  .subtitle {
+    color: #9ba7c3;
+  }
+
+  .config input,
+  .heading-row input {
+    border-color: #3b4866;
+    background: #121620;
+    color: inherit;
+  }
+
+  button {
+    background: linear-gradient(135deg, #3399ff, #1c62d5);
+  }
+
+  .status pre {
+    background: #121620;
+    border-color: #28324a;
+  }
+
+  .status pre.error {
+    color: #ff6b8c;
+  }
+}

--- a/public/ui-preview.svg
+++ b/public/ui-preview.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="420" viewBox="0 0 800 420" role="img" aria-labelledby="title desc">
+  <title id="title">Simrad Autopilot control panel preview</title>
+  <desc id="desc">Illustration of the Signal K Simrad autopilot web control panel with four primary mode buttons.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f0f0f0"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000000" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+  <rect width="800" height="420" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <rect x="80" y="60" width="640" height="300" rx="18" fill="#ffffff" stroke="#d9dce1" stroke-width="2"/>
+  </g>
+  <text x="400" y="120" text-anchor="middle" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="34" font-weight="600" fill="#1e3146">Simrad Autopilot Control</text>
+  <g font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="500">
+    <rect x="140" y="180" width="130" height="64" rx="12" fill="#f5f7fb" stroke="#b5bfd1"/>
+    <text x="205" y="222" text-anchor="middle" fill="#20334a">Standby</text>
+
+    <rect x="290" y="180" width="130" height="64" rx="12" fill="#294f9b" stroke="#183970"/>
+    <text x="355" y="222" text-anchor="middle" fill="#ffffff">Auto</text>
+
+    <rect x="440" y="180" width="130" height="64" rx="12" fill="#f5f7fb" stroke="#b5bfd1"/>
+    <text x="505" y="222" text-anchor="middle" fill="#20334a">Wind</text>
+
+    <rect x="590" y="180" width="130" height="64" rx="12" fill="#f5f7fb" stroke="#b5bfd1"/>
+    <text x="655" y="222" text-anchor="middle" fill="#20334a">Track</text>
+  </g>
+  <g font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="18" font-weight="500" fill="#526179">
+    <text x="400" y="275" text-anchor="middle">Quick commands via REST endpoints</text>
+    <text x="400" y="305" text-anchor="middle">/plus1 /minus1 /plus10 /minus10 /tack /gybe</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- serve the UI index file for both GET and HEAD requests under /signalk-autopilot-simrad
- move the alias middleware to the front of the Express stack so it wins over the plugin metadata route

## Testing
- node -e "require('./index.js')"

------
https://chatgpt.com/codex/tasks/task_e_68c9ea2ba4708327b235198d229e4de6