### PR TITLE
Add plugin router UI fallback for older Signal K hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A Signal K server plugin for controlling **Simrad SimNet/NMEA 2000 tillerpilots** (TP22/TP32 and compatible pilots) by transmitting **PGN 127237 – Heading/Track Control**. The plugin targets gateways that accept raw NMEA 2000 frames over UDP using the Yacht Devices `YDRAW` format and exposes both REST and Signal K `PUT` interfaces for steering commands.
 
-Once enabled, Signal K registers the plugin under the slug `signalk-autopilot-simrad`, which means the REST API is available at `/plugins/signalk-autopilot-simrad/*` and the optional UI is hosted at `/signalk-autopilot-simrad/`.
+Once enabled, Signal K registers the plugin under the slug `signalk-autopilot-simrad`, which means the REST API is available at `/plugins/signalk-autopilot-simrad/*` and the optional UI is hosted at `/signalk-autopilot-simrad/` (with the same assets also reachable at `/plugins/signalk-autopilot-simrad/` for older hosts that rely on the plugin router fallback).
 
 ## Features
 
@@ -90,6 +90,12 @@ A minimal web UI lives in [`public/`](public/) for experimentation or further de
 
 ```
 http://<your-server>:3000/signalk-autopilot-simrad/
+```
+
+Signal K releases that lack `registerPluginWebapp` (or where the admin Express app isn’t exposed) use a router-based fallback, so the same UI is also reachable via:
+
+```
+http://<your-server>:3000/plugins/signalk-autopilot-simrad/
 ```
 
 The UI calls the REST endpoints above from the browser so you can drive the pilot directly. It is designed as a starting point—feel free to customise the layout or embed it into your own dashboards.


### PR DESCRIPTION
## Summary
- add a router-based fallback that serves the plugin UI from `public/` when the host cannot expose it via `registerPluginWebapp` or the UI alias
- reuse shared helpers for the UI alias, update logging, and track fallback reasons for easier debugging
- document the additional `/plugins/signalk-autopilot-simrad/` access path for the UI fallback in the README

## Testing
- node -e "require('./index.js');"


------
https://chatgpt.com/codex/tasks/task_e_68ca12f94e6c83278a57429f2e4cd99c