### PR TITLE
Simplify UI alias handling for older Signal K hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A Signal K server plugin for controlling **Simrad SimNet/NMEA 2000 tillerpilots** (TP22/TP32 and compatible pilots) by transmitting **PGN 127237 – Heading/Track Control**. The plugin targets gateways that accept raw NMEA 2000 frames over UDP using the Yacht Devices `YDRAW` format and exposes both REST and Signal K `PUT` interfaces for steering commands.
 
-Once enabled, Signal K registers the plugin under the slug `signalk-autopilot-simrad`, which means the REST API is available at `/plugins/signalk-autopilot-simrad/*` and the optional UI is hosted at `/signalk-autopilot-simrad/`.
+Once enabled, Signal K registers the plugin under the slug `signalk-autopilot-simrad`, which means the REST API is available at `/plugins/signalk-autopilot-simrad/*` and the optional UI lives at `/plugins/signalk-autopilot-simrad/` (with `/signalk-autopilot-simrad/` kept as a convenience alias on hosts that expose the admin Express app).
 
 ## Features
 
@@ -87,6 +87,12 @@ The handler returns `state: "SUCCESS"` on completion or provides an error messag
 ## Optional UI stub
 
 A minimal web UI lives in [`public/`](public/) for experimentation or further development. When the plugin is enabled, Signal K serves it automatically at:
+
+```
+http://<your-server>:3000/plugins/signalk-autopilot-simrad/
+```
+
+If the host exposes the admin Express app, the plugin also registers a shortcut that redirects to the same assets:
 
 ```
 http://<your-server>:3000/signalk-autopilot-simrad/

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 const dgram = require('dgram');
-const fs = require('fs');
 const path = require('path');
 
 const PLUGIN_ID = 'signalk-autopilot-simrad';
 const UI_ROUTE = `/${PLUGIN_ID}`;
 const REST_BASE_PATH = `/plugins/${PLUGIN_ID}`;
+const PUBLIC_DIR = path.join(__dirname, 'public');
 
 const MODE_MAP = {
   standby: 0,
@@ -77,7 +77,8 @@ module.exports = function simradAutopilotPlugin(app) {
   let routesRegistered = false;
   let putHandlersRegistered = false;
   let webAppRegistered = false;
-  let uiAliasLayer = null;
+  let uiAliasApp = null;
+  let uiAliasLayers = [];
 
   function updateCurrentHeading() {
     const preferTrue = config.headingReference === 'true';
@@ -458,104 +459,66 @@ module.exports = function simradAutopilotPlugin(app) {
   }
 
   function registerUiAlias() {
-    if (uiAliasLayer) {
+    if (uiAliasLayers.length) {
       return;
     }
 
-    const expressApp =
-      (typeof app.getExpressApp === 'function' && app.getExpressApp()) ||
-      app.expressApp ||
-      (app.server && app.server.app) ||
-      null;
-
-    if (!expressApp || typeof expressApp.use !== 'function') {
+    const expressApp = app.express;
+    if (!expressApp || typeof expressApp.get !== 'function') {
       app.debug(
-        `Express application not available; cannot mount UI alias at ${UI_ROUTE}`
+        `Express not available; use ${REST_BASE_PATH}/ for the UI`
       );
       return;
     }
 
-    let express;
-    try {
-      express = require('express');
-    } catch (err) {
-      app.error(
-        `Express dependency not available; cannot expose UI alias at ${UI_ROUTE}: ${err.message}`
-      );
-      return;
-    }
-
-    const staticDir = path.join(__dirname, 'public');
-    const indexPath = path.join(staticDir, 'index.html');
-
-    const router = express.Router();
-    const serveIndex = (_req, res, next) => {
-      fs.access(indexPath, fs.constants.R_OK, (accessErr) => {
-        if (accessErr) {
-          next(accessErr);
-          return;
-        }
-        res.sendFile(indexPath, (sendErr) => {
-          if (sendErr) {
-            next(sendErr);
-          }
-        });
-      });
+    const redirectTarget = `${REST_BASE_PATH}/`;
+    const handler = (_req, res) => {
+      res.redirect(redirectTarget);
     };
-    router.get('/', serveIndex);
-    router.head('/', serveIndex);
-    router.use('/', express.static(staticDir, { redirect: false }));
 
-    expressApp.use(UI_ROUTE, router);
+    const paths = [UI_ROUTE, `${UI_ROUTE}/`];
+    uiAliasApp = expressApp;
 
-    if (expressApp._router && Array.isArray(expressApp._router.stack)) {
-      const stack = expressApp._router.stack;
-      const index = stack.findIndex((layer) => layer && layer.handle === router);
-      if (index > 0) {
-        const [layer] = stack.splice(index, 1);
-        stack.unshift(layer);
-        app.debug(
-          `Elevated Simrad autopilot UI alias to the front of the Express stack for ${UI_ROUTE}`
-        );
+    paths.forEach((aliasPath) => {
+      expressApp.get(aliasPath, handler);
+      if (expressApp._router && Array.isArray(expressApp._router.stack)) {
+        const layer = expressApp._router.stack[expressApp._router.stack.length - 1];
+        if (layer && !uiAliasLayers.includes(layer)) {
+          uiAliasLayers.push(layer);
+        }
       }
-    }
+    });
 
-    uiAliasLayer = { app: expressApp, router };
-    app.debug(`Mounted Simrad autopilot UI alias at ${UI_ROUTE}`);
+    app.debug(`UI alias mounted at ${UI_ROUTE} → ${redirectTarget}`);
   }
 
   function unregisterUiAlias() {
-    if (!uiAliasLayer) {
+    if (!uiAliasLayers.length) {
       return;
     }
 
-    const { app: expressApp, router } = uiAliasLayer;
-    if (expressApp && expressApp._router && Array.isArray(expressApp._router.stack)) {
-      expressApp._router.stack = expressApp._router.stack.filter(
-        (layer) => layer && layer.handle !== router
+    if (uiAliasApp && uiAliasApp._router && Array.isArray(uiAliasApp._router.stack)) {
+      uiAliasApp._router.stack = uiAliasApp._router.stack.filter(
+        (layer) => !uiAliasLayers.includes(layer)
       );
     }
 
-    uiAliasLayer = null;
+    uiAliasLayers = [];
+    uiAliasApp = null;
   }
 
   function registerWebApp() {
     if (!webAppRegistered && typeof app.registerPluginWebapp === 'function') {
       try {
-        app.registerPluginWebapp(
-          plugin.id,
-          plugin.name,
-          path.join(__dirname, 'public')
-        );
+        app.registerPluginWebapp(plugin.id, plugin.name, PUBLIC_DIR);
         webAppRegistered = true;
         app.debug(`Registered Simrad autopilot UI at /plugins/${PLUGIN_ID}`);
       } catch (err) {
         app.error(`Failed to register Simrad autopilot UI: ${err.message}`);
+        app.debug(`UI assets remain available at ${REST_BASE_PATH}/`);
       }
     } else if (!webAppRegistered) {
-      app.debug(
-        'Signal K host does not support registerPluginWebapp; skipping admin UI registration.'
-      );
+      app.debug(`Signal K host does not support registerPluginWebapp; use ${REST_BASE_PATH}/ for the UI`);
     }
 
     registerUiAlias();
@@ -618,6 +581,7 @@ module.exports = function simradAutopilotPlugin(app) {
   plugin.registerWithRouter = (router) => {
     const wasRegistered = routesRegistered;
     addRoutes(router);
+
     if (!wasRegistered && routesRegistered) {
       app.debug(`Simrad autopilot REST endpoints mounted at ${REST_BASE_PATH}/*`);
     }


### PR DESCRIPTION
## Summary
- rely on the built-in `/plugins/signalk-autopilot-simrad/` static hosting instead of mounting router fallbacks
- only register the `/signalk-autopilot-simrad/` redirect when the host exposes `app.express`
- document the default and optional UI paths in the README

## Testing
- node -e "require('./index.js');"


------
https://chatgpt.com/codex/tasks/task_e_68ca12f94e6c83278a57429f2e4cd99c